### PR TITLE
Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea/
+.build

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Bolt",
         "repositoryURL": "https://github.com/Neo4j-Swift/Bolt-swift.git",
         "state": {
-          "branch": "master",
-          "revision": "eb6cec91e458ddaf819b403bbf29fe5a318a6f30",
-          "version": null
+          "branch": null,
+          "revision": "9858a43c9a26373d64069a6f046db5ab45db4cb0",
+          "version": "5.2.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.1"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
-        .package(name: "Theo", url: "https://github.com/Neo4j-Swift/Neo4j-Swift.git", .branch("master")),
-        .package(url: "https://github.com/Neo4j-Swift/Bolt-swift.git", .branch("master"))
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.31.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.3"),
+        .package(name: "Theo", url: "https://github.com/Neo4j-Swift/Neo4j-Swift.git", .branch("master"))
     ],
     
     targets: [

--- a/Sources/GraphifyEvolution/GraphAnalyser/Entities/DataBaseController.swift
+++ b/Sources/GraphifyEvolution/GraphAnalyser/Entities/DataBaseController.swift
@@ -11,6 +11,10 @@ import Theo
 import PackStream
 import Dispatch
 
+#if os(Linux)
+  import FoundationNetworking
+#endif
+
 class Node {
     var label: String
     var id: Int?


### PR DESCRIPTION
Updating dependencies versions resolved all of the errors related to Foundation because dependencies already added Linux support to their package. 

Added required imports for linux
